### PR TITLE
deno.json formatting and linting

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -1,11 +1,33 @@
 {
 	"importMap": "importMap.json",
 	"tasks": {
-		"install": "deno install -A -f -n dash_compiler ./mod.ts",
+		"install": "deno install -A --reload -f -n dash_compiler ./mod.ts",
 		"install:full": "deno install -A --reload -f -n dash_compiler ./mod.ts",
 		"build": "deno task build:apple-x86 && deno task build:apple-aarch64 && deno task build:windows-x86",
 		"build:apple-x86": "deno compile --target x86_64-apple-darwin --output ./executables/dash-apple-x64 -A ./mod.ts",
 		"build:apple-aarch64": "deno compile --target aarch64-apple-darwin --output ./executables/dash-apple-aarch64 -A ./mod.ts",
 		"build:windows-x86": "deno compile --target x86_64-pc-windows-msvc  --output ./executables/dash.exe -A ./mod.ts"
+	},
+	"fmt": {
+		"files": {
+			"include": ["*.json", "*.ts", "*.tsx", "src/"]
+		},
+		"options": {
+			"useTabs": true,
+			"lineWidth": 80,
+			"indentWidth": 4,
+			"singleQuote": true
+		}
+	},
+	"lint": {
+		"files": {
+			"include": ["*.ts", "src/"],
+			"exclude": ["dist/", ".vscode/", ".github/"]
+		},
+		"rules": {
+			"tags": ["recommended"],
+			"include": ["ban-untagged-todo"],
+			"exclude": []
+		}
 	}
 }

--- a/deno.json
+++ b/deno.json
@@ -1,7 +1,7 @@
 {
 	"importMap": "importMap.json",
 	"tasks": {
-		"install": "deno install -A --reload -f -n dash_compiler ./mod.ts",
+		"install": "deno install -A -f -n dash_compiler ./mod.ts",
 		"install:full": "deno install -A --reload -f -n dash_compiler ./mod.ts",
 		"build": "deno task build:apple-x86 && deno task build:apple-aarch64 && deno task build:windows-x86",
 		"build:apple-x86": "deno compile --target x86_64-apple-darwin --output ./executables/dash-apple-x64 -A ./mod.ts",


### PR DESCRIPTION
Added `fmt` and `lint` properties to the deno.json file. Necessary for collaboration.

TODO: Add a `deno fmt` format step to GitHub workflow.