### PR TITLE
Ignore on relative file paths to prevent watch mode ignoring all

### DIFF
--- a/src/CLIWatcher.ts
+++ b/src/CLIWatcher.ts
@@ -27,9 +27,9 @@ export class CLIWatcher {
 			if (['success', 'other', 'any'].includes(event.kind)) continue
 
 			event.paths.forEach((path) => {
-				if (this.ignorePath(path)) return
-
 				const transformed = this.transformPath(path)
+				
+				if (this.ignorePath(transformed)) return
 				if (transformed.match(outputFolderPattern)) return
 
 				if (event.kind === 'create' || event.kind === 'modify') {
@@ -51,11 +51,12 @@ export class CLIWatcher {
 			.replace(/\\/g, '/')
 	}
 
-	ignorePath(path: string) {
+	ignorePath(filePath: string) {
 		return (
-			path.endsWith('.crswap') ||
-			path.endsWith('.DS_Store') ||
-			path.includes('.bridge')
+			filePath.endsWith('.crswap') ||
+			filePath.endsWith('.DS_Store') ||
+			filePath.startsWith('.bridge') ||
+			filePath.startsWith('.git')
 		)
 	}
 

--- a/src/CLIWatcher.ts
+++ b/src/CLIWatcher.ts
@@ -9,7 +9,7 @@ export class CLIWatcher {
 	constructor(protected dash: Dash) {}
 
 	async watch(reloadPort?: number) {
-		console.log(`Dash is starting to watch "${this.dash.projectRoot}"!`)
+		console.log(`Dash is starting to watch "${path.resolve(this.dash.projectRoot)}"!`)
 
 		const watcher = Deno.watchFs(this.dash.projectRoot)
 		const wsServer = new WebSocketServer()


### PR DESCRIPTION
If you use dash to watch a project in the default bridge project location it will silently fail.
This is because `CLIWatcher.ignorePath` discards any file with `.bridge` in its path which is all files in `C:\Users\User\AppData\Local\com.bridge.dev\bridge\projects\`

I switched it to look at the start of the relative path for `.bridge` and added a check for `.git` paths as a bonus.