### PR TITLE
Support using a dash-config.json before defaulting to config.json

### DIFF
--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { CLIWatcher } from './CLIWatcher.ts'
 import { comMojangFolder, previewComMojangFolder } from './comMojangFolder.ts'
-import { Dash, isMatch, path} from './deps.ts'
+import { Dash, isMatch, path } from './deps.ts'
 import { DenoFileSystem } from './FileSystem.ts'
 import { FileTypeImpl, PackTypeImpl } from './McProjectCore.ts'
 

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -19,7 +19,6 @@ export class CLI {
 
 		const dash = new Dash(this.fs, outFs, {
 			config:  await this.getProjectConfig(),
-			//config: path.join(Deno.cwd(), './config.json'),
 			compilerConfig: compilerConfig
 				? path.join(Deno.cwd(), compilerConfig)
 				: undefined,

--- a/src/CLI.ts
+++ b/src/CLI.ts
@@ -1,7 +1,7 @@
 // deno-lint-ignore-file no-explicit-any
 import { CLIWatcher } from './CLIWatcher.ts'
 import { comMojangFolder, previewComMojangFolder } from './comMojangFolder.ts'
-import { Dash, isMatch, path } from './deps.ts'
+import { Dash, isMatch, path} from './deps.ts'
 import { DenoFileSystem } from './FileSystem.ts'
 import { FileTypeImpl, PackTypeImpl } from './McProjectCore.ts'
 
@@ -18,7 +18,8 @@ export class CLI {
 		const outFs = out ? new DenoFileSystem(out) : undefined
 
 		const dash = new Dash(this.fs, outFs, {
-			config: path.join(Deno.cwd(), './config.json'),
+			config:  await this.getProjectConfig(),
+			//config: path.join(Deno.cwd(), './config.json'),
 			compilerConfig: compilerConfig
 				? path.join(Deno.cwd(), compilerConfig)
 				: undefined,
@@ -50,6 +51,17 @@ export class CLI {
 		if (options.mode === 'development' && options.out === undefined) {
 			options.out = comMojangFolder ?? undefined
 		}
+	}
+
+	async getProjectConfig(){
+		let projectConfigPath = ''
+		 try {
+			await this.fs.readFile('dash-config.json')
+			projectConfigPath = path.join(Deno.cwd(), './dash-config.json')
+		} catch (_error) {
+			projectConfigPath = path.join(Deno.cwd(), './config.json')
+		}
+		return projectConfigPath;
 	}
 
 	async build(options: IDashOptions) {


### PR DESCRIPTION
## Summary
Adds support for using a `dash-config.json` file rather than `config.json` for instances where `config.json` is used by another system.
- Check if `dash-config.json` exists; if it does, use this as the project config. If it doesn't assume `config.json` is the project config like normal.

## Impact
This is needed for a project currently being worked on.

## Testing
- Confirm that if no `dash-config.json` exists `config.json` is still used
- Confirm that if `dash-config.json` exists it is used instead of `config.json`